### PR TITLE
v0.8.4: major update of libraries and images

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ paths in your zookeeper:
 <hr/>
 
 ###### Important changes
+ - 0.8.4:
+   - Major update of libraries and images
+   - Support of v2 ClickHouse jdbc driver (v1 for standalone mode)
+   - Aligning license with the original project
  - Since version 0.8.1 the plugin uses Zookeeper for storing information about migrations.
  - The version 0.8.0 is not back-compatible with previous versions.
  - From the version 0.8.0 the extension adapted for the liquibase v4.26, Java baseline changed to 17, clickhouse baseline is

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
                 <configuration>
                     <licenseName>apache_v2</licenseName>
                     <licenseFile>LICENSE</licenseFile>
-                    <canUpdateCopyright>true</canUpdateCopyright>
+                    <canUpdateCopyright>false</canUpdateCopyright>
                     <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
                     <includes>
                         <include>**/*.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.genestack</groupId>
     <artifactId>liquibase-clickhouse</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.4</version>
     <packaging>jar</packaging>
     <inceptionYear>2020</inceptionYear>
 
@@ -14,7 +14,7 @@
     <url>https://github.com/genestack/liquibase-clickhouse</url>
 
     <organization>
-        <name>Genestack LTD</name>
+        <name>Genestack Limited</name>
         <url>https://genestack.com</url>
     </organization>
 
@@ -47,6 +47,11 @@
             <name>Oleg Kunitsyn</name>
             <organization>Genestack</organization>
         </contributor>
+        <contributor>
+            <email>mikhail.smazhevsky@genestack.com</email>
+            <name>Mikhail Smazhevsky</name>
+            <organization>Genestack</organization>
+        </contributor>
     </contributors>
 
     <scm>
@@ -67,38 +72,24 @@
     <properties>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <clickhouse-jdbc.version>0.6.0-patch1</clickhouse-jdbc.version>
-        <liquibase.version>4.26.0</liquibase.version>
-        <junit.version>5.4.0</junit.version>
-        <test-containers.version>1.19.7</test-containers.version>
-        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <maven-plugin-plugin.version>3.9.6</maven-plugin-plugin.version>
-        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-        <license-maven-plugin.version>2.0.0</license-maven-plugin.version>
-        <maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
-        <fmt-maven-plugin.version>2.9.1</fmt-maven-plugin.version>
-        <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
-        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
-        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-        <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
-        <snakeyaml.version>2.2</snakeyaml.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <clickhouse-jdbc.version>0.8.5</clickhouse-jdbc.version>
+        <liquibase.version>4.31.1</liquibase.version>
+        <junit.version>5.12.2</junit.version>
+        <test-containers.version>1.21.0</test-containers.version>
+        <snakeyaml.version>2.4</snakeyaml.version>
         <typesafe-config.version>1.4.3</typesafe-config.version>
-        <junit.version>5.10.2</junit.version>
-        <slf4j.version>2.0.12</slf4j.version>
-        <apache.http5.version>5.3.1</apache.http5.version>
-        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
-        <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
-        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-        <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
-        <snakeyaml.version>2.2</snakeyaml.version>
-        <typesafe-config.version>1.4.3</typesafe-config.version>
-        <junit.version>5.10.2</junit.version>
-        <slf4j.version>2.0.12</slf4j.version>
-        <apache.http5.version>5.3.1</apache.http5.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <apache.http5.version>5.2.1</apache.http5.version> <!--should be aligned with version in clickhouse-jdbc.pom-->
+        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+        <license-maven-plugin.version>2.5.0</license-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
+        <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+        <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     </properties>
 
     <dependencies>
@@ -266,7 +257,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.5.0</version>
+                <version>${central-publishing-maven-plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended"],
+    "schedule": ["* * 1 */2 *"],
+    "updateNotScheduled": false,
+    "labels": ["renovate"],
+    "dockerfile": {
+        "managerFilePatterns": [
+            "/(^|/)(?:[\\w.-]+-)(?:docker-)?compose[^/]*\\.ya?ml$/"
+        ]
+    },
+    "regexManagers": [
+        {
+            "fileMatch": ["^.*Images\\.java$"],
+            "matchStrings": [
+                "\\s*static\\s*final\\s*String\\s*(.*)\\s*=\\s*\"(?<depName>.*):(?<currentValue>.*)\""
+            ],
+            "datasourceTemplate": "docker"
+        }
+    ]
+}

--- a/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
+++ b/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
@@ -1,8 +1,9 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2020 - 2023 Mediarithmics
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/lockservice/ClickHouseLockService.java
+++ b/src/main/java/liquibase/ext/clickhouse/lockservice/ClickHouseLockService.java
@@ -1,8 +1,9 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2020 - 2023 Mediarithmics
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/params/ClusterConfig.java
+++ b/src/main/java/liquibase/ext/clickhouse/params/ClusterConfig.java
@@ -2,7 +2,8 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2020 - 2023 Mediarithmics
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/params/LiquibaseClickHouseConfig.java
+++ b/src/main/java/liquibase/ext/clickhouse/params/LiquibaseClickHouseConfig.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/params/LiquibaseConfigVisitor.java
+++ b/src/main/java/liquibase/ext/clickhouse/params/LiquibaseConfigVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/params/ParamsLoader.java
+++ b/src/main/java/liquibase/ext/clickhouse/params/ParamsLoader.java
@@ -2,7 +2,8 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2020 - 2023 Mediarithmics
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LiquibaseSqlTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LiquibaseSqlTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/ModifyDataTypeClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/ModifyDataTypeClickHouse.java
@@ -1,8 +1,9 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2020 - 2023 Mediarithmics
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/OnClusterTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/OnClusterTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/SqlGeneratorUtil.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/SqlGeneratorUtil.java
@@ -1,8 +1,9 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2020 - 2023 Mediarithmics
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/ChangelogColumns.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/ChangelogColumns.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/CreateDatabaseChangeLogTableClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/CreateDatabaseChangeLogTableClickHouse.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/RemoveChangeSetRanStatusClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/RemoveChangeSetRanStatusClickHouse.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/TagDatabaseGeneratorClickhouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/TagDatabaseGeneratorClickhouse.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/UpdateChangeSetChecksumClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/UpdateChangeSetChecksumClickHouse.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/template/CreateDatabaseChangeLogTableTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/template/CreateDatabaseChangeLogTableTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/template/RemoveChangeSetRanStatusTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/template/RemoveChangeSetRanStatusTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/template/UpsertTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/template/UpsertTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/CreateDatabaseChangeLogLockTableClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/CreateDatabaseChangeLogLockTableClickHouse.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/InitializeDatabaseChangeLogLockClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/InitializeDatabaseChangeLogLockClickHouse.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/LockDatabaseChangeLogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/LockDatabaseChangeLogClickHouse.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/SelectFromDatabaseChangeLogLockGeneratorClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/SelectFromDatabaseChangeLogLockGeneratorClickHouse.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/UnlockDatabaseChangelogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/UnlockDatabaseChangelogClickHouse.java
@@ -1,8 +1,9 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2020 - 2023 Mediarithmics
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/CreateDatabaseChangeLogLockTableTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/CreateDatabaseChangeLogLockTableTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/InitialLockRecordTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/InitialLockRecordTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/LockTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/LockTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/SelectLockTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/SelectLockTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/TruncateTableTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/TruncateTableTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/UnlockTemplate.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/template/UnlockTemplate.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/liquibase/ClickHouseTest.java
+++ b/src/test/java/liquibase/ClickHouseTest.java
@@ -1,8 +1,9 @@
 /*-
  * #%L
- * Liquibase extension for Clickhouse
+ * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2020 - 2023 Mediarithmics
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +20,10 @@
  */
 package liquibase;
 
+import com.clickhouse.jdbc.JdbcConfig;
 import liquibase.ext.clickhouse.params.StandaloneConfig;
 import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -29,8 +31,9 @@ import java.sql.Connection;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("JUnitTestCaseWithNoTests")
 @Testcontainers
-public class ClickHouseTest extends BaseClickHouseTest {
+public class ClickHouseTest extends BaseClickHouseTestCase {
 
 
     @BeforeAll
@@ -39,12 +42,12 @@ public class ClickHouseTest extends BaseClickHouseTest {
     }
 
     @Container
-    private static final ClickHouseContainer clickHouseContainer =
-        new ClickHouseContainer("clickhouse/clickhouse-server:24.4.3");
+    private static final ClickHouseContainer clickHouseContainer = new ClickHouseContainer(Images.CLICKHOUSE);
 
     @Override
-    protected void doWithConnection(BaseClickHouseTest.ThrowingConsumer<Connection> consumer) {
-        try (Connection connection = clickHouseContainer.createConnection("")) {
+    protected void doWithConnection(BaseClickHouseTestCase.ThrowingConsumer<Connection> consumer) {
+        String queryString = "?clickhouse.jdbc.v1=true&" + JdbcConfig.PROP_EXTERNAL_DATABASE + "=false";
+        try (Connection connection = clickHouseContainer.createConnection(queryString)) {
             consumer.accept(connection);
         } catch (Exception e) {
             fail(e);

--- a/src/test/java/liquibase/CustomChange.java
+++ b/src/test/java/liquibase/CustomChange.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/liquibase/Images.java
+++ b/src/test/java/liquibase/Images.java
@@ -17,11 +17,12 @@
  * limitations under the License.
  * #L%
  */
-package liquibase.ext.clickhouse.params;
+package liquibase;
 
-public final class StandaloneConfig implements LiquibaseClickHouseConfig {
-    @Override
-    public <T> T accept(LiquibaseConfigVisitor<T> visitor) {
-        return visitor.visit(this);
+final class Images {
+    static final String CLICKHOUSE = "clickhouse/clickhouse-server:25.3.2";
+
+    private Images() {
+        // Prevent instantiation
     }
 }

--- a/src/test/java/liquibase/ParamsLoaderTest.java
+++ b/src/test/java/liquibase/ParamsLoaderTest.java
@@ -2,7 +2,8 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2024 Genestack LTD
+ * Copyright (C) 2020 - 2023 Mediarithmics
+ * Copyright (C) 2024 - 2025 Genestack Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/changelog-cluster.xml
+++ b/src/test/resources/changelog-cluster.xml
@@ -1,12 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2011-2021 Genestack Limited
-  ~ All Rights Reserved
-  ~ THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF GENESTACK LIMITED
-  ~ The copyright notice above does not evidence any
-  ~ actual or intended publication of such source code.
-  -->
-
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/test/resources/changelog.xml
+++ b/src/test/resources/changelog.xml
@@ -2,6 +2,6 @@
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
     <include file="test-script.sql"/>
 </databaseChangeLog>

--- a/src/test/resources/clickhouse-cluster/clickhouse-s2r2-compose.yml
+++ b/src/test/resources/clickhouse-cluster/clickhouse-s2r2-compose.yml
@@ -14,13 +14,13 @@
 
 services:
   zookeeper:
-    image: zookeeper:3.9.2
+    image: zookeeper:3.9.3
     ports:
       - 2181
     hostname: zookeeper
 
   clickhouse-s1r1:
-    image: clickhouse/clickhouse-server:24.4.3
+    image: clickhouse/clickhouse-server:25.3.2
     hostname: clickhouse-s1r1
     ports:
       - 8123
@@ -36,9 +36,11 @@ services:
       - ./../../../../../log/clickhouse-s1r1-server:/var/log/clickhouse-server
     depends_on:
       - zookeeper
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: 1
 
   clickhouse-s1r2:
-    image: clickhouse/clickhouse-server:24.4.3
+    image: clickhouse/clickhouse-server:25.3.2
     hostname: clickhouse-s1r2
     ports:
       - 8123
@@ -54,9 +56,11 @@ services:
       - ./../../../../../log/clickhouse-s1r2-server:/var/log/clickhouse-server
     depends_on:
       - zookeeper
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: 1
 
   clickhouse-s2r1:
-    image: clickhouse/clickhouse-server:24.4.3
+    image: clickhouse/clickhouse-server:25.3.2
     hostname: clickhouse-s2r1
     ports:
       - 8123
@@ -72,9 +76,11 @@ services:
       - ./../../../../../log/clickhouse-s2r1-server:/var/log/clickhouse-server
     depends_on:
       - zookeeper
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: 1
 
   clickhouse-s2r2:
-    image: clickhouse/clickhouse-server:24.4.3
+    image: clickhouse/clickhouse-server:25.3.2
     hostname: clickhouse-s2r2
     ports:
       - 8123
@@ -90,9 +96,11 @@ services:
       - ./../../../../../log/clickhouse-s2r2-server:/var/log/clickhouse-server
     depends_on:
       - zookeeper
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: 1
 
   nginx:
-    image: nginx:1.27.0
+    image: nginx:1.27.4
     ports:
       - 8123
     volumes:

--- a/src/test/resources/clickhouse-cluster/config.xml
+++ b/src/test/resources/clickhouse-cluster/config.xml
@@ -67,7 +67,11 @@
     <!-- Directory in <clickhouse-path> containing schema files for various input formats. The directory will be created if it doesn't exist. -->
     <format_schema_path>/var/lib/clickhouse/format_schema/</format_schema_path>
 
-    <users_config>users.xml</users_config>
+    <user_directories>
+        <users_xml>
+            <path>users.xml</path>
+        </users_xml>
+    </user_directories>
 
     <default_profile>default</default_profile>
     <default_database>default</default_database>

--- a/src/test/resources/clickhouse-cluster/users.xml
+++ b/src/test/resources/clickhouse-cluster/users.xml
@@ -1,36 +1,10 @@
-<?xml version="1.0"?>
-<!--
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+<clickhouse>
+    <!-- See also the files in users.d directory where the settings can be overridden. -->
 
-    https://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License. See accompanying LICENSE file.
--->
-<yandex>
     <!-- Profiles of settings. -->
     <profiles>
         <!-- Default settings. -->
         <default>
-            <!-- Maximum memory usage for processing single query, in bytes. -->
-            <max_memory_usage>10000000000</max_memory_usage>
-
-            <!-- How to choose between replicas during distributed query processing.
-                 random - choose random replica from set of replicas with minimum number of errors
-                 nearest_hostname - from set of replicas with minimum number of errors, choose replica
-                  with minimum number of different symbols between replica's hostname and local hostname
-                  (Hamming distance).
-                 in_order - first live replica is chosen in specified order.
-                 first_or_random - if first replica one has higher number of errors, pick a random one from replicas with minimum number of errors.
-            -->
-            <load_balancing>random</load_balancing>
-            <!-- Enable Map support -->
-            <allow_experimental_map_type>1</allow_experimental_map_type>
         </default>
 
         <!-- Profile that allows only read queries. -->
@@ -43,7 +17,9 @@
     <users>
         <!-- If user name was not specified, 'default' user is used. -->
         <default>
-            <!-- Password could be specified in plaintext or in SHA256 (in hex format).
+            <!-- See also the files in users.d directory where the password can be overridden.
+
+                 Password could be specified in plaintext or in SHA256 (in hex format).
 
                  If you want to specify password in plaintext (not recommended), place it in 'password' element.
                  Example: <password>qwerty</password>.
@@ -56,8 +32,17 @@
                  If you want to specify double SHA1, place it in 'password_double_sha1_hex' element.
                  Example: <password_double_sha1_hex>e395796d6546b1b65db9d665cd43f0e858dd4303</password_double_sha1_hex>
 
-                 If you want to specify a previously defined LDAP server (see 'ldap_servers' in main config) for authentication, place its name in 'server' element inside 'ldap' element.
+                 If you want to specify a previously defined LDAP server (see 'ldap_servers' in the main config) for authentication,
+                  place its name in 'server' element inside 'ldap' element.
                  Example: <ldap><server>my_ldap_server</server></ldap>
+
+                 If you want to authenticate the user via Kerberos (assuming Kerberos is enabled, see 'kerberos' in the main config),
+                  place 'kerberos' element instead of 'password' (and similar) elements.
+                 The name part of the canonical principal name of the initiator must match the user name for authentication to succeed.
+                 You can also place 'realm' element inside 'kerberos' element to further restrict authentication to only those requests
+                  whose initiator's realm matches it.
+                 Example: <kerberos />
+                 Example: <kerberos><realm>EXAMPLE.COM</realm></kerberos>
 
                  How to generate decent password:
                  Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" | sha256sum | tr -d '-'
@@ -81,9 +66,9 @@
                  Each element of list has one of the following forms:
                  <ip> IP-address or network mask. Examples: 213.180.204.3 or 10.0.0.1/8 or 10.0.0.1/255.255.255.0
                      2a02:6b8::3 or 2a02:6b8::3/64 or 2a02:6b8::3/ffff:ffff:ffff:ffff::.
-                 <host> Hostname. Example: server01.yandex.ru.
+                 <host> Hostname. Example: server01.clickhouse.com.
                      To check access, DNS query is performed, and all received addresses compared to peer address.
-                 <host_regexp> Regular expression for host names. Example, ^server\d\d-\d\d-\d\.yandex\.ru$
+                 <host_regexp> Regular expression for host names. Example, ^server\d\d-\d\d-\d\.clickhouse\.com$
                      To check access, DNS PTR query is performed for peer address and then regexp is applied.
                      Then, for result of PTR query, another DNS query is performed and all received addresses compared to peer address.
                      Strongly recommended that regexp is ends with $
@@ -100,7 +85,17 @@
             <quota>default</quota>
 
             <!-- User can create other users and grant rights to them. -->
-            <!-- <access_management>1</access_management> -->
+            <access_management>1</access_management>
+
+            <!-- User can manipulate named collections. -->
+            <named_collection_control>1</named_collection_control>
+
+            <!-- User permissions can be granted here -->
+            <!--
+            <grants>
+                <query>GRANT ALL ON *.*</query>
+            </grants>
+            -->
         </default>
     </users>
 
@@ -122,4 +117,4 @@
             </interval>
         </default>
     </quotas>
-</yandex>
+</clickhouse>

--- a/src/test/resources/custom-change.xml
+++ b/src/test/resources/custom-change.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!--
-  ~ Copyright (c) 2011-2021 Genestack Limited
-  ~ All Rights Reserved
-  ~ THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF GENESTACK LIMITED
-  ~ The copyright notice above does not evidence any
-  ~ actual or intended publication of such source code.
-  -->
-
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog

--- a/src/test/resources/empty-changelog.xml
+++ b/src/test/resources/empty-changelog.xml
@@ -2,5 +2,5 @@
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
 </databaseChangeLog>

--- a/src/test/resources/init-cluster.xml
+++ b/src/test/resources/init-cluster.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!--
-  ~ Copyright (c) 2011-2021 Genestack Limited
-  ~ All Rights Reserved
-  ~ THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF GENESTACK LIMITED
-  ~ The copyright notice above does not evidence any
-  ~ actual or intended publication of such source code.
-  -->
-
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog

--- a/src/test/resources/insert-data.xml
+++ b/src/test/resources/insert-data.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!--
-  ~ Copyright (c) 2011-2021 Genestack Limited
-  ~ All Rights Reserved
-  ~ THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF GENESTACK LIMITED
-  ~ The copyright notice above does not evidence any
-  ~ actual or intended publication of such source code.
-  -->
-
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog


### PR DESCRIPTION
0.8.4:
 - Major update of libraries and images
 - Support of v2 ClickHouse jdbc driver (v1 for standalone mode)
 - Aligning license with the original project


P.S. v2 for standalone mode doesn't work because of differences in java.sql.DatabaseMetaData#getColumns implementation: DatabaseMetaDataImpl (jdbc driver v2) doesn't convert values of columns like DATA_TYPE to int, so liquibase can't parse them.