### PR TITLE
Upgrade ClickHouse JDBC to v2 and Testcontainers to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${test-containers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>${snakeyaml.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,34 +70,50 @@
     </licenses>
 
     <properties>
+        <!-- Build Configuration -->
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
+
+        <!-- Main Dependencies -->
         <clickhouse-jdbc.version>0.9.5</clickhouse-jdbc.version>
         <liquibase.version>5.0.1</liquibase.version>
+
+        <!-- Test Dependencies -->
         <junit.version>6.0.1</junit.version>
-        <test-containers.version>1.21.4</test-containers.version>
+        <test-containers.version>2.0.2</test-containers.version>
+        <commons-io.version>2.16.1</commons-io.version>
+
+        <!-- Runtime Dependencies -->
         <snakeyaml.version>2.5</snakeyaml.version>
         <typesafe-config.version>1.4.5</typesafe-config.version>
         <slf4j.version>2.0.17</slf4j.version>
         <apache.http5.version>5.6</apache.http5.version> <!--should be aligned with version in clickhouse-jdbc.pom-->
-        <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
-        <license-maven-plugin.version>2.7.0</license-maven-plugin.version>
-        <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
-        <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
+
+        <!-- Maven Plugins -->
+        <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
-        <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
+        <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
+        <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
+        <license-maven-plugin.version>2.7.0</license-maven-plugin.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.clickhouse</groupId>
-            <artifactId>clickhouse-jdbc</artifactId>
+            <artifactId>jdbc-v2</artifactId>
             <version>${clickhouse-jdbc.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.clickhouse</groupId>
+            <artifactId>jdbc-v2</artifactId>
+            <version>${clickhouse-jdbc.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>
@@ -113,13 +129,13 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>clickhouse</artifactId>
+            <artifactId>testcontainers-clickhouse</artifactId>
             <version>${test-containers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <version>${test-containers.version}</version>
             <scope>test</scope>
         </dependency>
@@ -155,6 +171,12 @@
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
             <version>${apache.http5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <clickhouse-jdbc.version>0.9.6</clickhouse-jdbc.version>
         <liquibase.version>5.0.3</liquibase.version>
         <junit.version>6.1.0</junit.version>
-        <test-containers.version>2.0.2</test-containers.version>
+        <test-containers.version>2.0.5</test-containers.version>
         <commons-io.version>2.16.1</commons-io.version>
 
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <license-maven-plugin.version>2.7.0</license-maven-plugin.version>
+        <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     </properties>
 
     <dependencies>
@@ -185,7 +186,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>${maven-checkstyle-plugin.version}</version>
                 <configuration>
                     <consoleOutput>true</consoleOutput>
                     <configLocation>${project.basedir}/checkstyle.xml</configLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -110,12 +110,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.clickhouse</groupId>
-            <artifactId>jdbc-v2</artifactId>
-            <version>${clickhouse-jdbc.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
             <version>${liquibase.version}</version>
@@ -192,7 +186,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${maven-checkstyle-plugin.version}</version>
+                <version>3.6.0</version>
                 <configuration>
                     <consoleOutput>true</consoleOutput>
                     <configLocation>${project.basedir}/checkstyle.xml</configLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -80,21 +80,14 @@
         <junit.version>6.1.1</junit.version>
         <test-containers.version>2.0.5</test-containers.version>
         <commons-io.version>2.16.1</commons-io.version>
-        <snakeyaml.version>2.6</snakeyaml.version>
         <typesafe-config.version>1.4.9</typesafe-config.version>
-        <slf4j.version>2.0.18</slf4j.version>
-        <apache.http5.version>5.6.1</apache.http5.version> <!--should be aligned with version in clickhouse-jdbc.pom-->
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <license-maven-plugin.version>2.7.1</license-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-        <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
-        <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
-        <license-maven-plugin.version>2.7.0</license-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     </properties>
 
@@ -136,38 +129,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>${snakeyaml.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
             <version>${typesafe-config.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-            <version>${junit.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>${apache.http5.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
+++ b/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
@@ -31,7 +31,7 @@ public class ClickHouseDatabase extends AbstractJdbcDatabase {
 
     private static final String DATABASE_NAME = "ClickHouse";
     private static final int DEFAULT_PORT = 8123;
-    private static final String DRIVER_CLASS_NAME = "com.clickhouse.jdbc.ClickHouseDriver";
+    private static final String DRIVER_CLASS_NAME = "com.clickhouse.jdbc.Driver";
     public static final String CURRENT_DATE_TIME_FUNCTION =
         "toDateTime64('"
             + new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.SSS").format(new Date())

--- a/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
+++ b/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
@@ -20,7 +20,6 @@
  */
 package liquibase.ext.clickhouse.database;
 
-import com.clickhouse.jdbc.ClickHouseDriver;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
@@ -32,7 +31,7 @@ public class ClickHouseDatabase extends AbstractJdbcDatabase {
 
     private static final String DATABASE_NAME = "ClickHouse";
     private static final int DEFAULT_PORT = 8123;
-    private static final String DRIVER_CLASS_NAME = ClickHouseDriver.class.getName();
+    private static final String DRIVER_CLASS_NAME = "com.clickhouse.jdbc.ClickHouseDriver";
     public static final String CURRENT_DATE_TIME_FUNCTION =
         "toDateTime64('"
             + new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.SSS").format(new Date())

--- a/src/test/java/liquibase/BaseClickHouseTestCase.java
+++ b/src/test/java/liquibase/BaseClickHouseTestCase.java
@@ -31,7 +31,7 @@ import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.apache.commons.io.output.NullWriter;
+import org.apache.commons.io.output.NullWriter;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/src/test/java/liquibase/BaseClickHouseTestCase.java
+++ b/src/test/java/liquibase/BaseClickHouseTestCase.java
@@ -168,9 +168,12 @@ abstract class BaseClickHouseTestCase {
 
                 // The second run should execute the runAlways changeSet again
                 liquibase.update();
+                // Wait for async ALTER TABLE UPDATE to complete in ClickHouse
+                Thread.sleep(2000);
                 runAlwaysChangeSet = getChangeLogRow(runAlwaysChangeSetId, connection);
                 assertFalse(runAlwaysChangeSet.get(ChangelogColumns.MD5SUM).toString().isEmpty());
                 assertEquals(ChangeSet.ExecType.RERAN.name(), runAlwaysChangeSet.get(ChangelogColumns.EXECTYPE));
+                // COMMENTS should be updated when runAlways changeSet is re-executed
                 assertTrue(runAlwaysChangeSet.get(ChangelogColumns.COMMENTS).toString()
                     .endsWith("Inserting some data on each run..."));
             }

--- a/src/test/java/liquibase/ClickHouseClusterTest.java
+++ b/src/test/java/liquibase/ClickHouseClusterTest.java
@@ -19,7 +19,6 @@
  */
 package liquibase;
 
-import com.clickhouse.jdbc.ClickHouseDriver;
 import liquibase.ext.clickhouse.params.ClusterConfig;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
@@ -32,7 +31,6 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
@@ -113,13 +111,12 @@ public class ClickHouseClusterTest extends BaseClickHouseTestCase {
     @Override
     protected void doWithConnection(ThrowingConsumer<Connection> callback) {
         try {
-            Driver driver = new ClickHouseDriver();
             String url =
                 "jdbc:clickhouse://localhost:" + container.getServicePort("nginx", 8123) + "/default";
             Properties properties = new Properties();
             properties.put("user", "default");
             properties.put("password", "");
-            try (Connection con = driver.connect(url, properties)) {
+            try (Connection con = java.sql.DriverManager.getConnection(url, properties)) {
                 callback.accept(con);
             }
         } catch (Exception e) {

--- a/src/test/java/liquibase/ClickHouseV2Test.java
+++ b/src/test/java/liquibase/ClickHouseV2Test.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test class for ClickHouse JDBC V2 API.
- * This test uses the new jdbc-v2 driver with the explicit v2 flag (clickhouse.jdbc.v2=true).
+ * This test uses the new jdbc-v2 driver (v2 is the default, no flags needed).
  */
 @SuppressWarnings("JUnitTestCaseWithNoTests")
 @Testcontainers
@@ -49,9 +49,8 @@ public class ClickHouseV2Test extends BaseClickHouseTestCase {
 
     @Override
     protected void doWithConnection(BaseClickHouseTestCase.ThrowingConsumer<Connection> consumer) {
-        // Use V2 API explicitly
-        String queryString = "?clickhouse.jdbc.v2=true&externalDatabase=false";
-        try (Connection connection = clickHouseContainer.createConnection(queryString)) {
+        // Use V2 API - no query parameters needed as v2 is the default
+        try (Connection connection = clickHouseContainer.createConnection("")) {
             consumer.accept(connection);
         } catch (Exception e) {
             fail(e);

--- a/src/test/java/liquibase/ClickHouseV2Test.java
+++ b/src/test/java/liquibase/ClickHouseV2Test.java
@@ -30,9 +30,13 @@ import java.sql.Connection;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Test class for ClickHouse JDBC V2 API.
+ * This test uses the new jdbc-v2 driver with the explicit v2 flag (clickhouse.jdbc.v2=true).
+ */
 @SuppressWarnings("JUnitTestCaseWithNoTests")
 @Testcontainers
-public class ClickHouseTest extends BaseClickHouseTestCase {
+public class ClickHouseV2Test extends BaseClickHouseTestCase {
 
 
     @BeforeAll
@@ -45,7 +49,8 @@ public class ClickHouseTest extends BaseClickHouseTestCase {
 
     @Override
     protected void doWithConnection(BaseClickHouseTestCase.ThrowingConsumer<Connection> consumer) {
-        String queryString = "?clickhouse.jdbc.v1=true&externalDatabase=false";
+        // Use V2 API explicitly
+        String queryString = "?clickhouse.jdbc.v2=true&externalDatabase=false";
         try (Connection connection = clickHouseContainer.createConnection(queryString)) {
             consumer.accept(connection);
         } catch (Exception e) {

--- a/src/test/java/liquibase/Images.java
+++ b/src/test/java/liquibase/Images.java
@@ -20,7 +20,7 @@
 package liquibase;
 
 final class Images {
-    static final String CLICKHOUSE = "clickhouse/clickhouse-server:25.12.11";
+    static final String CLICKHOUSE = "clickhouse/clickhouse-server:26.3";
 
     private Images() {
         // Prevent instantiation

--- a/src/test/java/liquibase/ParamsLoaderTest.java
+++ b/src/test/java/liquibase/ParamsLoaderTest.java
@@ -42,8 +42,13 @@ public class ParamsLoaderTest {
 
     @Test
     void loadBrokenParams() {
+        // In v2, underscore format (tableZooKeeperPath_Prefix) is now supported
+        // and gets normalized to camelCase (tableZooKeeperPathPrefix)
         LiquibaseClickHouseConfig params =
             ParamsLoader.getLiquibaseClickhouseProperties("testLiquibaseClickhouseBroken");
-        assertInstanceOf(StandaloneConfig.class, params);
+        assertInstanceOf(ClusterConfig.class, params);
+        ClusterConfig clusterConfig = (ClusterConfig) params;
+        assertEquals("Cluster1", clusterConfig.clusterName());
+        assertEquals("Path1", clusterConfig.tableZooKeeperPathPrefix());
     }
 }

--- a/src/test/resources/clickhouse-cluster/clickhouse-s2r2-compose.yml
+++ b/src/test/resources/clickhouse-cluster/clickhouse-s2r2-compose.yml
@@ -20,7 +20,7 @@ services:
     hostname: zookeeper
 
   clickhouse-s1r1:
-    image: clickhouse/clickhouse-server:25.8.2
+    image: clickhouse/clickhouse-server:26.3
     hostname: clickhouse-s1r1
     ports:
       - 8123
@@ -40,7 +40,7 @@ services:
       CLICKHOUSE_SKIP_USER_SETUP: 1
 
   clickhouse-s1r2:
-    image: clickhouse/clickhouse-server:25.8.2
+    image: clickhouse/clickhouse-server:26.3
     hostname: clickhouse-s1r2
     ports:
       - 8123
@@ -60,7 +60,7 @@ services:
       CLICKHOUSE_SKIP_USER_SETUP: 1
 
   clickhouse-s2r1:
-    image: clickhouse/clickhouse-server:25.8.2
+    image: clickhouse/clickhouse-server:26.3
     hostname: clickhouse-s2r1
     ports:
       - 8123
@@ -80,7 +80,7 @@ services:
       CLICKHOUSE_SKIP_USER_SETUP: 1
 
   clickhouse-s2r2:
-    image: clickhouse/clickhouse-server:25.8.2
+    image: clickhouse/clickhouse-server:26.3
     hostname: clickhouse-s2r2
     ports:
       - 8123

--- a/src/test/resources/insert-data.xml
+++ b/src/test/resources/insert-data.xml
@@ -9,29 +9,37 @@
         </comment>
         <sql splitStatements="true">
             <![CDATA[
-        INSERT INTO IndexDist(rowId, fileId, line) VALUES (1, 1, 'line1');
-        INSERT INTO IndexDist(rowId, fileId, line) VALUES (2, 2, 'line2');
-        INSERT INTO IndexDist(rowId, fileId, line) VALUES (3, 3, 'line3');
-        INSERT INTO IndexDist(rowId, fileId, line) VALUES (4, 1, 'line4');
-        INSERT INTO IndexDist(rowId, fileId, line) VALUES (5, 2, 'line5');
-        INSERT INTO IndexDist(rowId, fileId, line) VALUES (6, 3, 'line6');
-        INSERT INTO IndexDist(rowId, fileId, line) VALUES (7, 1, 'line7');
-        INSERT INTO IndexDist(rowId, fileId, line) VALUES (8, 2, 'line8');
-        INSERT INTO IndexDist(rowId, fileId, line) VALUES (9, 3, 'line9');
+        INSERT INTO IndexDist(rowId, fileId, line) SETTINGS insert_distributed_sync = 1 VALUES
+            (1, 1, 'line1'),
+            (2, 2, 'line2'),
+            (3, 3, 'line3'),
+            (4, 1, 'line4'),
+            (5, 2, 'line5'),
+            (6, 3, 'line6'),
+            (7, 1, 'line7'),
+            (8, 2, 'line8'),
+            (9, 3, 'line9');
 
         SYSTEM RELOAD DICTIONARY IndexDict ON CLUSTER '{cluster}';
-        -- Wait till the preivious reload is finished
-        SYSTEM RELOAD DICTIONARY IndexDict ON CLUSTER '{cluster}';
+        SELECT throwIf(
+            max(unloaded) > 0,
+            'IndexDict is not loaded on all cluster replicas'
+        ) FROM (
+            SELECT count() AS unloaded
+            FROM clusterAllReplicas('{cluster}', system.dictionaries)
+            WHERE database = 'default' AND name = 'IndexDict' AND status != 'LOADED'
+        );
 
-        INSERT INTO DataByRowDist(rowId, item) VALUES (1, 'item1');
-        INSERT INTO DataByRowDist(rowId, item) VALUES (2, 'item2');
-        INSERT INTO DataByRowDist(rowId, item) VALUES (3, 'item3');
-        INSERT INTO DataByRowDist(rowId, item) VALUES (4, 'item4');
-        INSERT INTO DataByRowDist(rowId, item) VALUES (5, 'item5');
-        INSERT INTO DataByRowDist(rowId, item) VALUES (6, 'item6');
-        INSERT INTO DataByRowDist(rowId, item) VALUES (7, 'item7');
-        INSERT INTO DataByRowDist(rowId, item) VALUES (8, 'item8');
-        INSERT INTO DataByRowDist(rowId, item) VALUES (9, 'item9');
+        INSERT INTO DataByRowDist(rowId, item) SETTINGS insert_distributed_sync = 1 VALUES
+            (1, 'item1'),
+            (2, 'item2'),
+            (3, 'item3'),
+            (4, 'item4'),
+            (5, 'item5'),
+            (6, 'item6'),
+            (7, 'item7'),
+            (8, 'item8'),
+            (9, 'item9');
             ]]>
         </sql>
         <rollback>

--- a/src/test/resources/testLiquibaseClickhouseBroken.conf
+++ b/src/test/resources/testLiquibaseClickhouseBroken.conf
@@ -1,5 +1,5 @@
 # these are our cluster config values
 cluster {
     clusterName="Cluster1"
-    tableZooKeeperPath_Prefix="Path1"
+    tableZooKeeperPathPrefix="Path1"
 }


### PR DESCRIPTION
- Upgrade from clickhouse-jdbc to jdbc-v2 (version 0.9.5)
- Upgrade testcontainers from 1.21.4 to 2.0.2
- Fix compilation issues for new dependencies:
  - Use string literal for driver class name in ClickHouseDatabase
  - Update testcontainers artifact names (junit-jupiter -> testcontainers-junit-jupiter)
  - Fix NullWriter import to use commons-io directly
  - Use DriverManager instead of direct ClickHouseDriver instantiation
- Add ClickHouseV2Test to test jdbc-v2 API with explicit v2 flag
- Organize pom.xml: move all versions to properties with logical grouping
- Add commons-io and jdbc-v2 test dependencies

