### PR TITLE
Multi cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Maven dependency:
 ```
 
 The cluster mode can be activated by adding the **_liquibaseClickhouse.conf_** file
-to the classpath (liquibase/lib/). The file name can be changed by setting the system property
-`liquibase.clickhouse.configfile`. The file should contain the following properties:
+to the classpath (resource/).
 ```
 cluster {
     clusterName="{cluster}"
@@ -46,7 +45,23 @@ These example configuration will configure the plugin to create two
 paths in your zookeeper:
 - `/keeper/path/to/liquibase/liquibase/DATABASECHANGELOG`
 - `/keeper/path/to/liquibase/liquibase/DATABASECHANGELOGLOCK`
-<hr/>
+
+The library also provides ClickHouseScopeUtils,
+which allows configuring the ClickHouse configuration file per Liquibase execution.
+
+```java
+ClickHouseScopeUtils.withConfig(
+        "cluster.conf",
+        liquibase::afterPropertiesSet
+);
+```
+
+The configuration file must be located in the application classpath
+(typically in the resources directory). Only the file name should be specified.
+
+This allows using multiple ClickHouse datasources in the same application,
+where some datasources use cluster mode, others work in standalone mode,
+or are connected to different ClickHouse clusters.
 
 ###### Important changes
  - 0.8.5:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The configuration file must be located in the application classpath
 This allows using multiple ClickHouse datasources in the same application,
 where some datasources use cluster mode, others work in standalone mode,
 or are connected to different ClickHouse clusters.
+<hr/>
 
 ###### Important changes
  - 0.8.5:

--- a/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
+++ b/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
@@ -27,8 +27,12 @@ import liquibase.exception.DatabaseException;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import liquibase.ext.clickhouse.params.LiquibaseClickHouseConfig;
+import liquibase.ext.clickhouse.params.ParamsLoader;
 
 public class ClickHouseDatabase extends AbstractJdbcDatabase {
+
+    private LiquibaseClickHouseConfig liquibaseClickHouseConfig;
 
     private static final String DATABASE_NAME = "ClickHouse";
     private static final int DEFAULT_PORT = 8123;
@@ -96,5 +100,18 @@ public class ClickHouseDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsDDLInTransaction() {
         return false;
+    }
+
+    public LiquibaseClickHouseConfig getLiquibaseClickHouseConfig() {
+        if (liquibaseClickHouseConfig == null) {
+            liquibaseClickHouseConfig = ParamsLoader.getLiquibaseClickhouseProperties();
+        }
+        return liquibaseClickHouseConfig;
+    }
+
+    @Override
+    public void setConnection(DatabaseConnection conn) {
+        super.setConnection(conn);
+        liquibaseClickHouseConfig = ParamsLoader.getLiquibaseClickhouseProperties();
     }
 }

--- a/src/main/java/liquibase/ext/clickhouse/params/ParamsLoader.java
+++ b/src/main/java/liquibase/ext/clickhouse/params/ParamsLoader.java
@@ -43,9 +43,7 @@ public final class ParamsLoader {
 
     private static final Logger LOG = Scope.getCurrentScope().getLog(ParamsLoader.class);
 
-    private static final String CONF_FILE =
-        System.getProperty("liquibase.clickhouse.configfile", "liquibaseClickhouse");
-    private static LiquibaseClickHouseConfig liquibaseClickhouseProperties = null;
+    private static final String CONF_FILE = "liquibaseClickhouse";
 
     private static final Set<String> VALID_PROPERTIES =
         new HashSet<>(Arrays.asList("clusterName", "tableZooKeeperPathPrefix"));
@@ -99,11 +97,14 @@ public final class ParamsLoader {
     }
 
     public static LiquibaseClickHouseConfig getLiquibaseClickhouseProperties() {
-        if (liquibaseClickhouseProperties != null) {
-            return liquibaseClickhouseProperties;
+        try {
+            String value = Scope.getCurrentScope().get("liquibase.clickhouse.configfile", String.class);
+            if (value != null) {
+                return getLiquibaseClickhouseProperties(value);
+            }
+        } catch (Exception ignored) {
         }
-        liquibaseClickhouseProperties = getLiquibaseClickhouseProperties(CONF_FILE);
-        return liquibaseClickhouseProperties;
+        return getLiquibaseClickhouseProperties(CONF_FILE);
     }
 
     public static LiquibaseClickHouseConfig getLiquibaseClickhouseProperties(String configFile) {

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/CreateDatabaseChangeLogTableClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/CreateDatabaseChangeLogTableClickHouse.java
@@ -22,7 +22,6 @@ package liquibase.ext.clickhouse.sqlgenerator.changelog;
 import liquibase.database.Database;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
 import liquibase.ext.clickhouse.params.LiquibaseClickHouseConfig;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.sqlgenerator.SqlGeneratorUtil;
 import liquibase.ext.clickhouse.sqlgenerator.changelog.template.CreateDatabaseChangeLogTableTemplate;
 import liquibase.sql.Sql;
@@ -48,7 +47,7 @@ public class CreateDatabaseChangeLogTableClickHouse extends CreateDatabaseChange
         Database database,
         SqlGeneratorChain sqlGeneratorChain
     ) {
-        LiquibaseClickHouseConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+        LiquibaseClickHouseConfig properties = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
         String createTableQuery = properties.accept(new CreateDatabaseChangeLogTableTemplate(database));
         return SqlGeneratorUtil.generateSql(database, createTableQuery);
     }

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/MarkChangeSetRanGeneratorClickhouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/MarkChangeSetRanGeneratorClickhouse.java
@@ -27,7 +27,6 @@ import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.sqlgenerator.SqlGeneratorUtil;
 import liquibase.ext.clickhouse.sqlgenerator.changelog.template.UpdateTemplate;
 import liquibase.sql.Sql;
@@ -76,7 +75,7 @@ public class MarkChangeSetRanGeneratorClickhouse extends MarkChangeSetRanGenerat
         }
         // dealing with an update case
         ChangeSet changeSet = statement.getChangeSet();
-        var config = ParamsLoader.getLiquibaseClickhouseProperties();
+        var config = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
         var map = new EnumMap<>(ChangelogColumns.class);
         map.put(ChangelogColumns.DATEEXECUTED, new DatabaseFunction(database.getCurrentDateTimeFunction()));
         map.put(ChangelogColumns.ORDEREXECUTED, getOrderExecutedColumn(database));

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/RemoveChangeSetRanStatusClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/RemoveChangeSetRanStatusClickHouse.java
@@ -22,7 +22,6 @@ package liquibase.ext.clickhouse.sqlgenerator.changelog;
 import liquibase.database.Database;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
 import liquibase.ext.clickhouse.params.LiquibaseClickHouseConfig;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.sqlgenerator.SqlGeneratorUtil;
 import liquibase.ext.clickhouse.sqlgenerator.changelog.template.RemoveChangeSetRanStatusTemplate;
 import liquibase.sql.Sql;
@@ -48,7 +47,7 @@ public class RemoveChangeSetRanStatusClickHouse extends RemoveChangeSetRanStatus
         Database database,
         SqlGeneratorChain sqlGeneratorChain
     ) {
-        LiquibaseClickHouseConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+        LiquibaseClickHouseConfig properties = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
         String removeChangeSet =
             properties.accept(new RemoveChangeSetRanStatusTemplate(database, statement));
         return SqlGeneratorUtil.generateSql(database, removeChangeSet);

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/TagDatabaseGeneratorClickhouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/TagDatabaseGeneratorClickhouse.java
@@ -22,7 +22,6 @@ package liquibase.ext.clickhouse.sqlgenerator.changelog;
 import liquibase.database.Database;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
 import liquibase.ext.clickhouse.params.LiquibaseClickHouseConfig;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.sqlgenerator.SqlGeneratorUtil;
 import liquibase.ext.clickhouse.sqlgenerator.changelog.template.TagDatabaseGeneratorTemplate;
 import liquibase.sql.Sql;
@@ -45,7 +44,7 @@ public class TagDatabaseGeneratorClickhouse extends TagDatabaseGenerator {
     public Sql[] generateSql(
         TagDatabaseStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain
     ) {
-        LiquibaseClickHouseConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+        LiquibaseClickHouseConfig properties = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
         String tagDatabaseQuery = properties.accept(new TagDatabaseGeneratorTemplate(database, statement.getTag()));
         return SqlGeneratorUtil.generateSql(database, tagDatabaseQuery);
     }

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/UpdateChangeSetChecksumClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/UpdateChangeSetChecksumClickHouse.java
@@ -23,7 +23,6 @@ import liquibase.ChecksumVersion;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.sqlgenerator.SqlGeneratorUtil;
 import liquibase.ext.clickhouse.sqlgenerator.changelog.template.UpdateTemplate;
 import liquibase.sql.Sql;
@@ -52,7 +51,7 @@ public class UpdateChangeSetChecksumClickHouse extends UpdateChangeSetChecksumGe
         SqlGeneratorChain sqlGeneratorChain
     ) {
         ChangeSet changeSet = statement.getChangeSet();
-        var config = ParamsLoader.getLiquibaseClickhouseProperties();
+        var config = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
 
         var map = new EnumMap<>(ChangelogColumns.class);
         // author and filename can't be changed, as they are part of the primary key

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/UpdateGeneratorClickhouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changelog/UpdateGeneratorClickhouse.java
@@ -22,8 +22,6 @@ package liquibase.ext.clickhouse.sqlgenerator.changelog;
 import liquibase.database.Database;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
-import liquibase.ext.clickhouse.params.LiquibaseClickHouseConfig;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.params.StandaloneConfig;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
@@ -51,8 +49,8 @@ public class UpdateGeneratorClickhouse extends UpdateGenerator {
     public Sql[] generateSql(
         UpdateStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain
     ) {
-        LiquibaseClickHouseConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
-        if (properties instanceof StandaloneConfig) {
+        var config = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
+        if (config instanceof StandaloneConfig) {
             return super.generateSql(statement, database, sqlGeneratorChain);
         }
         return generateSqlForCluster(statement, database);

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/CreateDatabaseChangeLogLockTableClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/CreateDatabaseChangeLogLockTableClickHouse.java
@@ -22,7 +22,6 @@ package liquibase.ext.clickhouse.sqlgenerator.changeloglock;
 import liquibase.database.Database;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
 import liquibase.ext.clickhouse.params.LiquibaseClickHouseConfig;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.sqlgenerator.SqlGeneratorUtil;
 import liquibase.ext.clickhouse.sqlgenerator.changeloglock.template.CreateDatabaseChangeLogLockTableTemplate;
 import liquibase.sql.Sql;
@@ -49,7 +48,7 @@ public class CreateDatabaseChangeLogLockTableClickHouse
         Database database,
         SqlGeneratorChain sqlGeneratorChain
     ) {
-        LiquibaseClickHouseConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+        LiquibaseClickHouseConfig properties = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
         String createTableQuery =
             properties.accept(new CreateDatabaseChangeLogLockTableTemplate(database));
 

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/InitializeDatabaseChangeLogLockClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/InitializeDatabaseChangeLogLockClickHouse.java
@@ -22,7 +22,6 @@ package liquibase.ext.clickhouse.sqlgenerator.changeloglock;
 import liquibase.database.Database;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
 import liquibase.ext.clickhouse.params.LiquibaseClickHouseConfig;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.sqlgenerator.SqlGeneratorUtil;
 import liquibase.ext.clickhouse.sqlgenerator.changeloglock.template.InitialLockRecordTemplate;
 import liquibase.ext.clickhouse.sqlgenerator.changeloglock.template.TruncateTableTemplate;
@@ -52,7 +51,7 @@ public class InitializeDatabaseChangeLogLockClickHouse
         Database database,
         SqlGeneratorChain sqlGeneratorChain
     ) {
-        LiquibaseClickHouseConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+        LiquibaseClickHouseConfig properties = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
 
         String clearDatabaseQuery = properties.accept(new TruncateTableTemplate(database));
 

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/LockDatabaseChangeLogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/LockDatabaseChangeLogClickHouse.java
@@ -21,7 +21,6 @@ package liquibase.ext.clickhouse.sqlgenerator.changeloglock;
 
 import liquibase.database.Database;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.sqlgenerator.SqlGeneratorUtil;
 import liquibase.ext.clickhouse.sqlgenerator.changeloglock.template.LockTemplate;
 import liquibase.sql.Sql;
@@ -51,7 +50,7 @@ public class LockDatabaseChangeLogClickHouse extends LockDatabaseChangeLogGenera
         Database database,
         SqlGeneratorChain sqlGeneratorChain
     ) {
-        var config = ParamsLoader.getLiquibaseClickhouseProperties();
+        var config = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
         String host = String.format("%s %s (%s)", hostname, hostDescription, hostaddress);
         String lockQuery = config.accept(new LockTemplate(database, host));
         return SqlGeneratorUtil.generateSql(database, lockQuery);

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/SelectFromDatabaseChangeLogLockGeneratorClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/SelectFromDatabaseChangeLogLockGeneratorClickHouse.java
@@ -21,7 +21,6 @@ package liquibase.ext.clickhouse.sqlgenerator.changeloglock;
 
 import liquibase.database.Database;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.sqlgenerator.SqlGeneratorUtil;
 import liquibase.ext.clickhouse.sqlgenerator.changeloglock.template.SelectLockTemplate;
 import liquibase.sql.Sql;
@@ -48,7 +47,7 @@ public class SelectFromDatabaseChangeLogLockGeneratorClickHouse
         final Database database,
         SqlGeneratorChain sqlGeneratorChain
     ) {
-        var config = ParamsLoader.getLiquibaseClickhouseProperties();
+        var config = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
         String query = config.accept(new SelectLockTemplate(database, statement));
         return SqlGeneratorUtil.generateSql(database, query);
     }

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/UnlockDatabaseChangelogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/changeloglock/UnlockDatabaseChangelogClickHouse.java
@@ -22,7 +22,6 @@ package liquibase.ext.clickhouse.sqlgenerator.changeloglock;
 
 import liquibase.database.Database;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.ext.clickhouse.sqlgenerator.SqlGeneratorUtil;
 import liquibase.ext.clickhouse.sqlgenerator.changeloglock.template.UnlockTemplate;
 import liquibase.sql.Sql;
@@ -48,7 +47,7 @@ public class UnlockDatabaseChangelogClickHouse extends UnlockDatabaseChangeLogGe
         Database database,
         SqlGeneratorChain sqlGeneratorChain
     ) {
-        var config = ParamsLoader.getLiquibaseClickhouseProperties();
+        var config = ((ClickHouseDatabase) database).getLiquibaseClickHouseConfig();
         String unlockQuery = config.accept(new UnlockTemplate(database));
 
         return SqlGeneratorUtil.generateSql(database, unlockQuery);

--- a/src/main/java/liquibase/ext/clickhouse/util/ClickHouseScopeUtils.java
+++ b/src/main/java/liquibase/ext/clickhouse/util/ClickHouseScopeUtils.java
@@ -1,0 +1,60 @@
+package liquibase.ext.clickhouse.util;
+
+import java.util.Map;
+import liquibase.Scope;
+import liquibase.exception.LiquibaseException;
+
+/**
+ * Utility methods for executing Liquibase operations with
+ * a dedicated ClickHouse configuration file.
+ *
+ * <p>
+ * The configuration file is propagated through Liquibase {@link Scope}
+ * using the {@value #CONFIG_FILE_SCOPE_KEY} scope key.
+ * </p>
+ *
+ * <p>
+ * This allows different Liquibase executions within the same application
+ * to use different ClickHouse configurations, including:
+ * </p>
+ *
+ * <ul>
+ *     <li>clustered and standalone ClickHouse instances</li>
+ *     <li>different ClickHouse clusters</li>
+ * </ul>
+ *
+ * <p>
+ * The configuration file must be available in the application classpath
+ * (typically in the {@code resources} directory).
+ * </p>
+ */
+public class ClickHouseScopeUtils {
+
+    public static final String CONFIG_FILE_SCOPE_KEY = "liquibase.clickhouse.configfile";
+
+    private ClickHouseScopeUtils() {
+    }
+
+    public static void withConfig(String clickhouseConfigFile, Scope.ScopedRunner<?> runner) throws LiquibaseException {
+        if (clickhouseConfigFile == null || clickhouseConfigFile.isBlank()) {
+            try {
+                runner.run();
+                return;
+            } catch (LiquibaseException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new LiquibaseException(e);
+            }
+        }
+        try {
+            Scope.child(
+                    Map.of(CONFIG_FILE_SCOPE_KEY, clickhouseConfigFile),
+                    runner
+            );
+        } catch (LiquibaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new LiquibaseException(e);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for configuring ClickHouse cluster settings per Liquibase execution instead of relying on a single global configuration.

### Problem

Currently, the extension uses a global cached configuration loaded from the liquibase.clickhouse.configfile system property. This makes it impossible to use multiple ClickHouse datasources with different configurations in the same application.

Example unsupported scenarios:
- one datasource connected to a ClickHouse cluster and another to a standalone instance
- multiple datasources connected to different ClickHouse clusters

### Solution

This PR introduces:
- ClickHouseScopeUtils utility for executing Liquibase operations with a dedicated configuration file using Liquibase Scope
- per-database configuration resolution through ClickHouseDatabase
- removal of global cached configuration usage from SQL generators

Example usage:

java ClickHouseScopeUtils.withConfig(         "cluster.conf",         liquibase::afterPropertiesSet ); 

The configuration file is resolved from the application classpath (resources).

### Notes

- Backward compatibility is preserved
- Existing global configuration behavior continues to work
- No Spring dependencies were added
- Configuration is now isolated per Liquibase execution / datasource